### PR TITLE
[EventSourcing] Iterator all the things

### DIFF
--- a/src/Component/EventSourcing/Domain/AggregateHistory.php
+++ b/src/Component/EventSourcing/Domain/AggregateHistory.php
@@ -3,43 +3,56 @@ declare(strict_types=1);
 
 namespace Ubirak\Component\EventSourcing\Domain;
 
-final class AggregateHistory extends \SplFixedArray
+final class AggregateHistory implements \IteratorAggregate
 {
     private $aggregateId;
 
     private $versionId;
 
-    public function __construct(iterable $events, int $versionId = 0)
+    private $events;
+
+    public function __construct(\Iterator $events, int $versionId = 0)
     {
-        parent::__construct(count($events));
-
-        $index = 0;
-        foreach ($events as $event) {
-            if (null === $this->aggregateId) {
-                $this->aggregateId = $event->getAggregateId();
-            }
-
-            if (false === $this->aggregateId->equals($event->getAggregateId())) {
-                throw CorruptedAggregateHistory::byEventNotMatchingAggregateId($this->aggregateId, $event);
-            }
-            parent::offsetSet($index++, $event);
+        $firstEvent = $events->current();
+        if (null !== $firstEvent) {
+            $this->aggregateId = $firstEvent->getAggregateId();
         }
-
+        $this->events = $events;
         $this->versionId = $versionId;
     }
 
-    public static function fromEvents(iterable $events, int $versionId = 0): self
+    public static function fromEvents(\Iterator $events, int $versionId = 0): self
     {
         return new static($events, $versionId);
     }
 
-    public function getAggregateId(): IdentifiesAggregate
+    public function getAggregateId(): ?IdentifiesAggregate
     {
         return $this->aggregateId;
     }
 
-    public function getVersionId(): ?int
+    public function getVersionId(): int
     {
         return $this->versionId;
+    }
+
+    public function read(): \Generator
+    {
+        foreach ($this->events as $event) {
+            if (false === $this->aggregateId->equals($event->getAggregateId())) {
+                throw CorruptedAggregateHistory::byEventNotMatchingAggregateId($this->aggregateId, $event);
+            }
+            yield $event;
+        }
+    }
+
+    public function getIterator(): \Iterator
+    {
+        return $this->read();
+    }
+
+    public function toArray(): array
+    {
+        return iterator_to_array($this->read());
     }
 }

--- a/src/Component/EventSourcing/Domain/AggregateRoot.php
+++ b/src/Component/EventSourcing/Domain/AggregateRoot.php
@@ -25,7 +25,7 @@ abstract class AggregateRoot extends Entity
     {
         $aggregateRoot = new static($history->getAggregateId(), $history->getVersionId());
 
-        foreach ($history as $change) {
+        foreach ($history->read() as $change) {
             $aggregateRoot->apply($change);
         }
 
@@ -44,7 +44,7 @@ abstract class AggregateRoot extends Entity
             );
         }
 
-        return new AggregateHistory($this->popChanges(), $this->versionId);
+        return new AggregateHistory(new \ArrayIterator($this->popChanges()), $this->versionId);
     }
 
     protected function apply(Change $change): void

--- a/src/Component/EventSourcing/Tests/Units/Domain/AggregateHistory.php
+++ b/src/Component/EventSourcing/Tests/Units/Domain/AggregateHistory.php
@@ -17,10 +17,11 @@ class AggregateHistory extends atoum
                     $this->mockEventOnAggregateId('12334'),
                     $this->mockEventOnAggregateId('12335'),
                     $this->mockEventOnAggregateId('12334'),
-                ]
+                ],
+                $this->newTestedInstance(\SplFixedArray::fromArray($events))
             )
-            ->exception(function () use ($events) {
-                $this->newTestedInstance($events);
+            ->exception(function () {
+                iterator_to_array($this->testedInstance->read());
             })
                 ->isInstanceOf(\Ubirak\Component\EventSourcing\Domain\CorruptedAggregateHistory::class)
         ;
@@ -37,10 +38,39 @@ class AggregateHistory extends atoum
                 ]
             )
             ->when(
-                $this->newTestedInstance($events)
+                $this->newTestedInstance(\SplFixedArray::fromArray($events))
             )
             ->then
-                ->phpArray($this->testedInstance->toArray())->hasSize(3)
+                ->generator($this->testedInstance->read())->hasSize(3)
+        ;
+    }
+
+    public function test history read aggregate id from events()
+    {
+        $this
+            ->given(
+                $events = [
+                    $this->mockEventOnAggregateId('12334'),
+                    $this->mockEventOnAggregateId('12334'),
+                    $this->mockEventOnAggregateId('12334'),
+                ]
+            )
+            ->when(
+                $this->newTestedInstance(\SplFixedArray::fromArray($events))
+            )
+            ->then
+                ->phpObject($this->testedInstance->getAggregateId())->isEqualTo($this->mockIdentifiesAggregate('12334'))
+        ;
+    }
+
+    public function test empty history has no aggregate id()
+    {
+        $this
+            ->when(
+                $this->newTestedInstance(new \ArrayIterator())
+            )
+            ->then
+                ->variable($this->testedInstance->getAggregateId())->isNull()
         ;
     }
 }

--- a/src/Component/EventSourcing/Tests/Units/Domain/AggregateRoot.php
+++ b/src/Component/EventSourcing/Tests/Units/Domain/AggregateRoot.php
@@ -33,10 +33,11 @@ class AggregateRoot extends atoum
     {
         $this
             ->given(
+                $past = [
+                    new ProductWasAdded($this->mockIdentifiesAggregate('12334'), 'product1'),
+                ],
                 $sut = Basket::reconstituteFromHistory(
-                    \Ubirak\Component\EventSourcing\Domain\AggregateHistory::fromEvents([
-                        new ProductWasAdded($this->mockIdentifiesAggregate('12334'), 'product1'),
-                    ])
+                    \Ubirak\Component\EventSourcing\Domain\AggregateHistory::fromEvents(new \ArrayIterator($past))
                 )
             )
             ->when(
@@ -53,9 +54,9 @@ class AggregateRoot extends atoum
         $this
             ->given(
                 $sut = BasketV2::reconstituteFromHistory(
-                    \Ubirak\Component\EventSourcing\Domain\AggregateHistory::fromEvents([
+                    \Ubirak\Component\EventSourcing\Domain\AggregateHistory::fromEvents(new \ArrayIterator([
                         new ProductWasAdded($this->mockIdentifiesAggregate('12334'), 'product1', 'p12345'),
-                    ])
+                    ]))
                 )
             )
             ->when(


### PR DESCRIPTION
We allow to build history from iterator rather than iterable.

So we will be able to reconstitute aggregate from generator also (and save memory from a big amount of events)