### PR TITLE
Suppress deprecated warning when PHP 7.3

### DIFF
--- a/src/Component/Healthcheck/Destination.php
+++ b/src/Component/Healthcheck/Destination.php
@@ -26,7 +26,11 @@ final class Destination
      */
     public function __construct(string $uri)
     {
-        $this->uri = filter_var($uri, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED);
+        if (version_compare(PHP_VERSION, '7.3.0') >= 0) {
+            $this->uri = filter_var($uri, FILTER_VALIDATE_URL);
+        } else {
+            $this->uri = filter_var($uri, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED);
+        }
 
         if ($this->uri === false) {
             throw InvalidDestination::forUri($uri);


### PR DESCRIPTION
FILTER_FLAG_HOST_REQUIRED (int)
Require host in "validate_url" filter. (Deprecated per PHP 7.3 as it is implied in the filter already.)

https://www.php.net/manual/en/filter.constants.php